### PR TITLE
Reference valid repository with hooks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ To add one or more of the hooks into your repo:
 ..pre-commit-config.yaml
 ----
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/softwaremill/scala-pre-commit-hooks
     rev: {currentVersion}
     default_phase: push #change to commit if desired
     hooks: #mix and match any of the following:


### PR DESCRIPTION
The documentation should reference this repo as source of scala hooks