### PR TITLE
Add Scapegoat as supported commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,6 +22,14 @@
   pass_filenames: false
   always_run: true
   minimum_pre_commit_version: '0.19.0'
+- id: sbt-scalariform
+  name: scalariform formatting check
+  stages: [commit,push]
+  language: python_venv
+  entry: sbt-scalariform
+  pass_filenames: false
+  always_run: true
+  minimum_pre_commit_version: '0.19.0'
 - id: sbt-scalastyle
   name: scalastyle formatting check
   stages: [commit,push]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,6 +22,14 @@
   pass_filenames: false
   always_run: true
   minimum_pre_commit_version: '0.19.0'
+- id: sbt-scapegoat
+  name: scapegoat static analysis check
+  stages: [commit,push]
+  language: python_venv
+  entry: sbt-scapegoat
+  pass_filenames: false
+  always_run: true
+  minimum_pre_commit_version: '0.19.0'
 - id: sbt-wartremover
   name: Scala WartRemover plugin check
   language: python_venv

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,6 +22,14 @@
   pass_filenames: false
   always_run: true
   minimum_pre_commit_version: '0.19.0'
+- id: sbt-scalastyle
+  name: scalastyle formatting check
+  stages: [commit,push]
+  language: python_venv
+  entry: sbt-scalastyle
+  pass_filenames: false
+  always_run: true
+  minimum_pre_commit_version: '0.19.0'
 - id: sbt-scapegoat
   name: scapegoat static analysis check
   stages: [commit,push]

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ To add one or more of the hooks into your repo:
 ..pre-commit-config.yaml
 ----
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/softwaremill/scala-pre-commit-hooks
     rev: {currentVersion}
     default_phase: push #change to commit if desired
     hooks: #mix and match any of the following:

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,8 @@ Currently, they include the following:
 - `sbt-fatal-warnings` - turns on `-Xfatal-warnings`, runs a clean compilation on the given scope.
 - `sbt-unused-imports` - as above, but also adds the "unused imports" warning.
 - `sbt-scalafmt` - runs `scalafmtCheckAll`.
-- `sbt-scalastyle` - runs `scalastyle`.
+- `sbt-scalastyle` - runs the `scalastyle` plugin.
+- `sbt-scalariform` - runs the `scalariform` plugin.
 - `sbt-wartremover` - runs the wartremover plugin.
 - `sbt-scapegoat` - runs the scapegoat plugin.
 
@@ -48,6 +49,7 @@ repos:
         args: [--scope={defaultScope}]
     -   id: sbt-scalafmt
     -   id: sbt-scalastyle
+    -   id: sbt-scalariform
     -   id: sbt-wartremover #arguments are optional
         args: [--warts=Warts.unsafe, --scope={defaultScope}]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,7 @@ Currently, they include the following:
 - `sbt-fatal-warnings` - turns on `-Xfatal-warnings`, runs a clean compilation on the given scope.
 - `sbt-unused-imports` - as above, but also adds the "unused imports" warning.
 - `sbt-scalafmt` - runs `scalafmtCheckAll`.
+- `sbt-scalastyle` - runs `scalastyle`.
 - `sbt-wartremover` - runs the wartremover plugin.
 - `sbt-scapegoat` - runs the scapegoat plugin.
 
@@ -46,6 +47,7 @@ repos:
     -   id: sbt-unused-imports #includes fatal warnings, arguments optional
         args: [--scope={defaultScope}]
     -   id: sbt-scalafmt
+    -   id: sbt-scalastyle
     -   id: sbt-wartremover #arguments are optional
         args: [--warts=Warts.unsafe, --scope={defaultScope}]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -26,6 +26,7 @@ Currently, they include the following:
 - `sbt-unused-imports` - as above, but also adds the "unused imports" warning.
 - `sbt-scalafmt` - runs `scalafmtCheckAll`.
 - `sbt-wartremover` - runs the wartremover plugin.
+- `sbt-scapegoat` - runs the scapegoat plugin.
 
 To add one or more of the hooks into your repo:
 

--- a/pre_commit_hooks/sbt_scalariform.py
+++ b/pre_commit_hooks/sbt_scalariform.py
@@ -1,0 +1,15 @@
+from pre_commit_hooks.runner import run_sbt_command
+from colorama import init as colorama_init, Fore
+
+TASK_SCALARIFORM = 'scalariform'
+MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scalariform'
+MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: scalariform SBT plugin not present! See {Fore.BLUE}https://github.com/sbt/sbt-scalariform{Fore.RED} for installation instructions.'
+
+def main(argv=None):
+    colorama_init()
+
+    return run_sbt_command(TASK_SCALARIFORM, MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/pre_commit_hooks/sbt_scalastyle.py
+++ b/pre_commit_hooks/sbt_scalastyle.py
@@ -1,0 +1,15 @@
+from pre_commit_hooks.runner import run_sbt_command
+from colorama import init as colorama_init, Fore
+
+TASK_SCALASTYLE = 'scalastyle'
+MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scalastyle'
+MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: scalastyle SBT plugin not present! See {Fore.BLUE}http://www.scalastyle.org/sbt.html{Fore.RED} for installation instructions.'
+
+def main(argv=None):
+    colorama_init()
+
+    return run_sbt_command(f'; clean ; {TASK_SCALASTYLE}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/pre_commit_hooks/sbt_scapegoat.py
+++ b/pre_commit_hooks/sbt_scapegoat.py
@@ -1,0 +1,15 @@
+from pre_commit_hooks.runner import run_sbt_command
+from colorama import init as colorama_init, Fore
+
+TASK_SCAPEGOAT = 'scapegoat'
+MISSING_PLUGIN_CHECK_STRING = 'Not a valid key: scapegoat'
+MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: scapegoat SBT plugin not present! See {Fore.BLUE}https://github.com/sksamuel/sbt-scapegoat{Fore.RED} for installation instructions.'
+
+def main(argv=None):
+    colorama_init()
+
+    return run_sbt_command(f'; scapegoatClean ; {TASK_SCAPEGOAT}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ python_requires = >=3.6
 console_scripts =
     scalafmt = pre_commit_hooks.scalafmt:main
     sbt-fatal-warnings = pre_commit_hooks.sbt_fatal_warnings:main
+    sbt-scalariform = pre_commit_hooks.sbt_scalariform:main
     sbt-scalastyle = pre_commit_hooks.sbt_scalastyle:main
     sbt-scapegoat = pre_commit_hooks.sbt_scapegoat:main
     sbt-wartremover = pre_commit_hooks.sbt_wartremover:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,6 @@ python_requires = >=3.6
 console_scripts =
     scalafmt = pre_commit_hooks.scalafmt:main
     sbt-fatal-warnings = pre_commit_hooks.sbt_fatal_warnings:main
+    sbt-scalastyle = pre_commit_hooks.sbt_scalastyle:main
     sbt-scapegoat = pre_commit_hooks.sbt_scapegoat:main
     sbt-wartremover = pre_commit_hooks.sbt_wartremover:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =
-    sbt-wartremover = pre_commit_hooks.sbt_wartremover:main
     scalafmt = pre_commit_hooks.scalafmt:main
     sbt-fatal-warnings = pre_commit_hooks.sbt_fatal_warnings:main
+    sbt-scapegoat = pre_commit_hooks.sbt_scapegoat:main
+    sbt-wartremover = pre_commit_hooks.sbt_wartremover:main


### PR DESCRIPTION
This PR adds a scapegoat commit hook for static code analysis. 
For more details, see 
- https://github.com/sksamuel/scapegoat
- https://github.com/sksamuel/sbt-scapegoat 

(Also, I brought in a minor readme change from @ppiotrow 's fork)