### PR TITLE
python_env has been removed as an alias for python

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: sbt-fatal-warnings
   name: Scala fatal warnings
   stages: [commit,push]
-  language: python_venv
+  language: python
   entry: sbt-fatal-warnings
   pass_filenames: false
   always_run: true
@@ -9,7 +9,7 @@
 - id: sbt-unused-imports
   name: Scala unused imports (+ fatal warnings)
   stages: [commit,push]
-  language: python_venv
+  language: python
   entry: sbt-fatal-warnings --add_arg='-Ywarn-unused-import'
   pass_filenames: false
   always_run: true
@@ -17,14 +17,14 @@
 - id: sbt-scalafmt
   name: scalafmt formatting check
   stages: [commit,push]
-  language: python_venv
+  language: python
   entry: scalafmt
   pass_filenames: false
   always_run: true
   minimum_pre_commit_version: '0.19.0'
 - id: sbt-wartremover
   name: Scala WartRemover plugin check
-  language: python_venv
+  language: python
   stages: [commit,push]
   entry: sbt-wartremover
   pass_filenames: false


### PR DESCRIPTION
Change `language: python`

Currently broken in pre-commit without