### PR TITLE
Add `--client` default arg

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,8 +62,9 @@ are relevant for the hook's check. The default is `{defaultScope}`.
 
 [NOTE]
 --
-All hooks have an optional `project-dir` arugument, which is useful for monorepos that do not have a `build.sbt` in their root.
-All hooks have an optional `no-clean` arugument, which won't automatically run an `sbt clean` before executing the command.
+All hooks have an optional `project-dir` argument, which is useful for monorepos that do not have a `build.sbt` in their root.
+All hooks have an optional `no-clean` argument, which won't automatically run an `sbt clean` before executing the command.
+All hooks have an optional `client` argument, which will persist the SBT session across invocations on newer SBT versions.
 --
 
 [IMPORTANT]

--- a/pre_commit_hooks/runner.py
+++ b/pre_commit_hooks/runner.py
@@ -53,12 +53,13 @@ def run_sbt_command(
     opts: Opts = Opts(),
 ):
     print(f"Running SBT command: {task_def} with options: {opts}")
+    sbt_args = "--client" if opts.client else ""
     if opts.clean:
         task_def = f"; clean ; {task_def}"
     else:
         task_def = f"; {task_def}"
     sbt_process = subprocess.run(
-        ["sbt", task_def, "--client" if opts.client else ""],
+        [f"sbt {sbt_args} '{task_def}'"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         shell=True,

--- a/pre_commit_hooks/runner.py
+++ b/pre_commit_hooks/runner.py
@@ -9,6 +9,7 @@ class Opts:
     project_dir: str | None = None
     clean: bool = True
     varargs: dict = field(default_factory=dict)
+    client: bool = False
 
 
 def default_argparse(
@@ -28,12 +29,19 @@ def default_argparse(
         default=False,
         help="Turn off sbt clean. Default: False",
     )
+    arg_p.add_argument(
+        "--client",
+        action="store_true",
+        default=False,
+        help="Run sbt in --client mode, persisting sessions across commits. Default: False",
+    )
     for fn in additional_args:
         fn(arg_p)
     varags = vars(arg_p.parse_args(argv))
     return Opts(
         project_dir=varags.pop("project_dir", None),
         clean=not varags.pop("no_clean", False),
+        client=varags.pop("client", False),
         varargs=varags,
     )
 
@@ -50,7 +58,7 @@ def run_sbt_command(
     else:
         task_def = f"; {task_def}"
     sbt_process = subprocess.run(
-        [f"sbt '{task_def}'"],
+        ["sbt", task_def, "--client" if opts.client else ""],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         shell=True,


### PR DESCRIPTION
Newer versions of SBT support [the experimental `--client` flag](https://www.scala-sbt.org/2.x/docs/en/guide/sbt-components.html#sbtn-sbt---client), which persists an SBT server in the background and reuses it instead of starting and tearing down a new server on every invocation. For complex projects with lots of packages/keys, this is a dramatic difference:

```
$ time sbt scalafmtCheckAll
...
sbt scalafmtCheckAll  36.77s user 2.98s system 570% cpu 6.962 total

$ time sbt scalafmtCheckAll --client
...
sbt scalafmtCheckAll --client  0.03s user 0.05s system 24% cpu 0.350 total
```

Supporting this argument in the precommit hooks will reduce commit times by several seconds for larger Scala projects.

Since the feature is still experimental and not supported on all SBT versions, I set it to disabled by default.
